### PR TITLE
Fixing compilation for std < c++17

### DIFF
--- a/src/BleOtaSizes.h
+++ b/src/BleOtaSizes.h
@@ -24,5 +24,7 @@
 constexpr auto BLE_OTA_ATTR_OVERHEAD = BLE_OTA_MAX_MTU_SIZE - BLE_OTA_MAX_ATTR_SIZE;
 constexpr auto BLE_OTA_MTU_SIZE = BLE_OTA_ATTRIBUTE_SIZE + BLE_OTA_ATTR_OVERHEAD;
 
-static_assert(BLE_OTA_MTU_SIZE >= BLE_OTA_MIN_MTU_SIZE);
-static_assert(BLE_OTA_MTU_SIZE <= BLE_OTA_MAX_MTU_SIZE);
+static_assert(BLE_OTA_MTU_SIZE >= BLE_OTA_MIN_MTU_SIZE,
+    "OTA MTU size should be greater than minimum size.");
+static_assert(BLE_OTA_MTU_SIZE <= BLE_OTA_MAX_MTU_SIZE,
+    "OTA MTU size should be less than maximum size.");


### PR DESCRIPTION
`static_assert` requires a message argument in versions before c++17 (https://en.cppreference.com/w/cpp/language/static_assert).

The code was not compiling for me (using platformio and NimBLE).
So, i fixed it, introducing a message for the `static_assert` calls.